### PR TITLE
Feat(Ui): updates import fonts to static way

### DIFF
--- a/src/components/UiStyle/sub-components/Ui.jsx
+++ b/src/components/UiStyle/sub-components/Ui.jsx
@@ -1,8 +1,7 @@
+import React from 'react';
 import { createGlobalStyle } from 'styled-components';
 
-const Ui = createGlobalStyle`
-  @import url('https://fonts.googleapis.com/css?family=Fira+Mono');
-
+const Style = createGlobalStyle`
   body {
     margin: 0;
     padding: 0 0 90px 0;
@@ -21,5 +20,12 @@ const Ui = createGlobalStyle`
     padding: 2px 5px;
   }
 `;
+
+const Ui = () => (
+  <>
+    <Style />
+    <link href="https://fonts.googleapis.com/css?family=Fira+Mono" rel="stylesheet" />
+  </>
+);
 
 export default Ui;

--- a/src/components/UiStyle/sub-components/Ui.jsx
+++ b/src/components/UiStyle/sub-components/Ui.jsx
@@ -25,6 +25,7 @@ const Ui = () => (
   <>
     <Style />
     <link href="https://fonts.googleapis.com/css?family=Fira+Mono" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons&display=block" rel="stylesheet" />
   </>
 );
 


### PR DESCRIPTION
## Description

The font was not loading in storybook (branch: `fix/qtm-170`).

![image](https://user-images.githubusercontent.com/3389749/78289218-31891400-74f8-11ea-9999-c08cb8fb91f0.png)

and icons too

![image](https://user-images.githubusercontent.com/3389749/78289249-3cdc3f80-74f8-11ea-9dd1-f36d753161e8.png)

Thats occur because the update of styled component in branch `fix/qtm-170`, removes the import font via CSS to HTML way (`<link />`). So we need to update the storybook-ui to its new behavior.


## How to test

First, in Quantum, start the storybook in the branch `fix/qtm-170`.
removes the node_modules and install it again.
```
> rm -rf node_modules
> yarn 
> yarn storybook
```

See the behaviors of the fonts and icons of the storybook (not the Quantum components)
Confirming that we have a problem, go to the quantum-storybook-ui and use this branch and removes the current node_modules.
```
> rm -rf node_modules
```
Now, install install again:
```
yarn
```
With that, build it!
```
yarn build
```

copy the content of the `dist/` to the node_modules of Quantum:
```
> cp -Rf dist/* ../quantum/node_modules/@catho/quantum-storybook-ui/dist/
```

start the Quantum storybook again and see that the fonts and icons was loaded.